### PR TITLE
Return empty array when there are no children

### DIFF
--- a/lib/redd/objects/more_comments.rb
+++ b/lib/redd/objects/more_comments.rb
@@ -3,7 +3,8 @@ module Redd
     # The model for a morecomments object
     class MoreComments < Array
       def initialize(_, attributes)
-        super(attributes[:children])
+        #Return an empty arrar if there are no children
+        super(attributes[:children]) if attributes[:children]
       end
     end
   end


### PR DESCRIPTION
MoreComments can contain an empty MoreComments object that would though an error when trying to create the object. This avoids that issue