### PR TITLE
Add delete_flair and set_flair_template

### DIFF
--- a/lib/redd/models/subreddit.rb
+++ b/lib/redd/models/subreddit.rb
@@ -234,16 +234,14 @@ module Redd
         nil
       end
 
-      # Remove the flair from a Submission or User
-      # @param thing [User, Submission] an object from which to remove flair
-      def delete_flair(thing)
-        key = thing.is_a?(User) ? :name : :link
-
-        params = { key => thing.name }
+      # Remove the flair from a user
+      # @param thing [User, String] a User from which to remove flair
+      def delete_flair(user)
+        name = user.is_a?(User) ? user.name : user
 
         @client.post(
           "/r/#{get_attribute(:display_name)}/api/deleteflair",
-          params
+          name: name
         )
       end
 

--- a/lib/redd/models/subreddit.rb
+++ b/lib/redd/models/subreddit.rb
@@ -234,6 +234,38 @@ module Redd
         nil
       end
 
+      # Remove the flair from a Submission or User
+      # @param thing [User, Submission] an object from which to remove flair
+      def delete_flair(thing)
+        key = thing.is_a?(User) ? :name : :link
+
+        params = { key => thing.name }
+
+        @client.post(
+          "/r/#{get_attribute(:display_name)}/api/deleteflair",
+          params
+        )
+      end
+
+      # Set a flair template for a Submission or User
+      # @param thing [User, Submission] an object to assign a template to
+      # @param template_id [String] the UUID of the flair template to assign
+      # @param text [String] optional text for the flair
+      def set_flair_template(thing, template_id, text: nil)
+        key = thing.is_a?(User) ? :name : :link
+
+        params = {
+          key => thing.name,
+          flair_template_id: template_id,
+          text: text
+        }
+
+        @client.post(
+          "/r/#{get_attribute(:display_name)}/api/selectflair",
+          params
+        )
+      end
+
       # Add the subreddit to the user's subscribed subreddits.
       def subscribe(action: :sub, skip_initial_defaults: false)
         @client.post(


### PR DESCRIPTION
Two methods I use all the time. I tested delete_flair a few thousand times this past week.

`delete_flair` accepts either a User or a String because `flair_listing` returns an array of hashes without actual User objects, and I'd prefer not to build Users just to pull their name back out.

I also had a problem with flair_listing that I'll create an issue for.