### PR TITLE
Unmarshaller should skip responses with no kind

### DIFF
--- a/lib/redd/utilities/unmarshaller.rb
+++ b/lib/redd/utilities/unmarshaller.rb
@@ -35,7 +35,7 @@ module Redd
           if MAPPING.key?(response[:kind])
             return MAPPING[response[:kind]].new(@client, response[:data])
           end
-          
+
           raise "unknown type to unmarshal: #{response[:kind].inspect}"
         else
           response

--- a/lib/redd/utilities/unmarshaller.rb
+++ b/lib/redd/utilities/unmarshaller.rb
@@ -33,10 +33,10 @@ module Redd
           end
         elsif response[:kind]
           if MAPPING.key?(response[:kind])
-            MAPPING[response[:kind]].new(@client, response[:data])
-          else
-            raise "unknown type to unmarshal: #{response[:kind].inspect}"
+            return MAPPING[response[:kind]].new(@client, response[:data])
           end
+          
+          raise "unknown type to unmarshal: #{response[:kind].inspect}"
         else
           response
         end

--- a/lib/redd/utilities/unmarshaller.rb
+++ b/lib/redd/utilities/unmarshaller.rb
@@ -31,10 +31,14 @@ module Redd
           else
             Models::BasicModel.new(@client, response[:json][:data])
           end
-        elsif MAPPING.key?(response[:kind])
-          MAPPING[response[:kind]].new(@client, response[:data])
+        elsif response[:kind]
+          if MAPPING.key?(response[:kind])
+            MAPPING[response[:kind]].new(@client, response[:data])
+          else
+            raise "unknown type to unmarshal: #{response[:kind].inspect}"
+          end
         else
-          raise "unknown type to unmarshal: #{response[:kind].inspect}"
+          response
         end
       end
     end


### PR DESCRIPTION
Trying to run `flair_listing`, I ran into an error in Unmarshaller. Basically, it's trying to unmarshal something that's a hash, but doesn't have a `:kind` key in that hash.

I fixed it for my case by adding a check to see if `response[:kind]` even exists. If it's not there, there's no purpose behind trying to create an object.