### PR TITLE
Added Submission::link and Comment::comment_link

### DIFF
--- a/lib/redd/models/comment.rb
+++ b/lib/redd/models/comment.rb
@@ -205,8 +205,8 @@ module Redd
       #   @return [Boolean] whether the comment is distinguished
       property :distinguished?, from: :distinguished
 
-      # @return [String] the link to this specific comment
-      def comment_link
+      # @return [String] the url to this specific comment
+      def comment_url
         link.link + id
       end
 

--- a/lib/redd/models/comment.rb
+++ b/lib/redd/models/comment.rb
@@ -209,7 +209,7 @@ module Redd
       def comment_link
         link.link + id
       end
-      
+
       private
 
       def lazer_reload

--- a/lib/redd/models/comment.rb
+++ b/lib/redd/models/comment.rb
@@ -205,6 +205,11 @@ module Redd
       #   @return [Boolean] whether the comment is distinguished
       property :distinguished?, from: :distinguished
 
+      # @return [String] the link to this specific comment
+      def comment_link
+        link.link + id
+      end
+      
       private
 
       def lazer_reload

--- a/lib/redd/models/submission.rb
+++ b/lib/redd/models/submission.rb
@@ -103,7 +103,7 @@ module Redd
       end
 
       # @return [String] the **absolute** url to the submission
-      def link
+      def url
         "https://www.reddit.com#{permalink}"
       end
 

--- a/lib/redd/models/submission.rb
+++ b/lib/redd/models/submission.rb
@@ -102,6 +102,11 @@ module Redd
         client.post('/api/set_suggested_sort', id: read_attribute(:name), sort: suggested)
       end
 
+      # @return [String] the **absolute** url to the submission
+      def link
+        "https://www.reddit.com#{permalink}"
+      end
+      
       # @!attribute [r] sort_order
       #   @return [Symbol] the comment sort order
       property :sort_order, :nil

--- a/lib/redd/models/submission.rb
+++ b/lib/redd/models/submission.rb
@@ -106,7 +106,7 @@ module Redd
       def link
         "https://www.reddit.com#{permalink}"
       end
-      
+
       # @!attribute [r] sort_order
       #   @return [Symbol] the comment sort order
       property :sort_order, :nil


### PR DESCRIPTION
The method names are confusing.
Why does Submission::permalink return a relative path instead of an absolute path?
Why does Comment::link return the link to the submission instead of a link to the comment itself?