### PR TITLE
Update webmock and http dependencies to latest

### DIFF
--- a/redd.gemspec
+++ b/redd.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'http', '~> 2.2'
+  spec.add_dependency 'http', '~> 3.3'
 
   spec.add_development_dependency 'bundler', '~> 1.14'
   spec.add_development_dependency 'rake', '~> 12.0'
@@ -31,6 +31,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'rspec', '~> 3.5'
   spec.add_development_dependency 'simplecov', '~> 0.13'
-  spec.add_development_dependency 'webmock', '~> 2.3'
+  spec.add_development_dependency 'webmock', '~> 3.4'
   spec.add_development_dependency 'vcr', '~> 3.0'
 end


### PR DESCRIPTION
I'm using this gem in a project that also includes the `twitter` gem, which uses newer versions of the `http` and `webmock` gems.

I updated `redd`'s dependencies with no apparent ill effects.

As per [CONTRIBUTING.md](https://github.com/avinashbot/redd/blob/master/CONTRIBUTING.md) I've manually tested this change. I'm only using very basic functionality from `redd` so it's possible I've missed something, but to the best of my knowledge this should be okay. ¯\\\_(ツ)_/¯ 