### PR TITLE
Split Listing into two types, one of which automatically marshals children

### DIFF
--- a/lib/redd/models/comment.rb
+++ b/lib/redd/models/comment.rb
@@ -48,9 +48,9 @@ module Redd
       property :upvoted?, from: :likes
 
       # @!attribute [r] replies
-      #   @return [Listing<Comment>] the comment replies
+      #   @return [ModelListing<Comment>] the comment replies
       property :replies,
-               with: ->(r) { r.is_a?(Hash) ? Listing.new(client, r[:data]) : Listing.empty(client) }
+               with: ->(r) { r.is_a?(Hash) ? ModelListing.new(client, r[:data]) : ModelListing.empty(client) }
 
       # @!attribute [r] user_reports
       #   @return [Array<String>] user reports

--- a/lib/redd/models/listing.rb
+++ b/lib/redd/models/listing.rb
@@ -4,7 +4,8 @@ require_relative 'model'
 
 module Redd
   module Models
-    # A backward-expading listing of items.
+    # A backward-expading listing of hash objects.
+    # Used in the case where the listing is not built from Models.
     # @see Stream
     class Listing < Model
       include Enumerable
@@ -46,7 +47,7 @@ module Redd
 
       # @!attribute [r] children
       #   @return [Array<Model>] the listing's children
-      property :children, :required, with: ->(a) { a.map { |m| client.unmarshal(m) } }
+      property :children, :required
     end
   end
 end

--- a/lib/redd/models/live_thread.rb
+++ b/lib/redd/models/live_thread.rb
@@ -12,7 +12,7 @@ module Redd
       # @option params [String] :before return results before the given fullname
       # @option params [Integer] :count the number of items already seen in the listing
       # @option params [1..100] :limit the maximum number of things to return
-      # @return [Listing]
+      # @return [ModelListing]
       def updates(**params)
         client.model(:get, "/live/#{read_attribute(:id)}", params)
       end
@@ -66,7 +66,7 @@ module Redd
       # @option params [Integer] :count the number of items already seen in the listing
       # @option params [1..100] :limit the maximum number of things to return
       #
-      # @return [Listing<Submission>]
+      # @return [ModelListing<Submission>]
       def discussions(**params)
         client.model(:get, "/live/#{read_attribute(:id)}/discussions", params)
       end

--- a/lib/redd/models/model_listing.rb
+++ b/lib/redd/models/model_listing.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require_relative 'model'
+
+module Redd
+  module Models
+    # A backward-expading listing of model objects.
+	  # Used in the case where the listing is built from Models.
+    # @see Listing
+    class ModelListing < Listing
+      include Enumerable
+
+      # @!attribute [r] children
+      #   @return [Array<Models>] the listing's children, as model objects rather than hash objects
+      property :children, :required, with: ->(a) { a.map { |m| client.unmarshal(m) } }
+    end
+  end
+end

--- a/lib/redd/models/more_comments.rb
+++ b/lib/redd/models/more_comments.rb
@@ -8,7 +8,7 @@ module Redd
     class MoreComments < Model
       # Expand the object's children into a listing of Comments and MoreComments.
       # @param link [Submission] the submission the object belongs to
-      # @return [Listing<Comment, MoreComments>] the expanded children
+      # @return [ModelListing<Comment, MoreComments>] the expanded children
       def expand(link:)
         expand_recursive(link: link, lookup: {})
       end
@@ -85,7 +85,7 @@ module Redd
 
       # Expand the object's children into a listing of Comments and MoreComments.
       # @param link [Submission] the submission the object belongs to
-      # @return [Listing<Comment, MoreComments>] the expanded children
+      # @return [ModelListing<Comment, MoreComments>] the expanded children
       def expand_one(link:)
         params = { link_id: link.name, children: read_attribute(:children).join(',') }
         params[:sort] = link.sort_order if link.sort_order

--- a/lib/redd/models/multireddit.rb
+++ b/lib/redd/models/multireddit.rb
@@ -18,7 +18,7 @@ module Redd
       #   when sorting.
       #
       # @note The option :time only applies to the top and controversial sorts.
-      # @return [Listing<Submission>]
+      # @return [ModelListing<Submission>]
       def listing(sort, **params)
         params[:t] = params.delete(:time) if params.key?(:time)
         client.model(:get, "#{read_attribute(:path)}#{sort}", params)

--- a/lib/redd/models/paginated_listing.rb
+++ b/lib/redd/models/paginated_listing.rb
@@ -38,7 +38,7 @@ module Redd
       # @option options [Integer] :limit the maximum number of items to fetch
       # @yieldparam after [String] the fullname of the item to fetch after
       # @yieldparam limit [Integer] the number of items to fetch (max 100)
-      # @yieldreturn [Listing] the listing to return
+      # @yieldreturn [ModelListing] the listing to return
       def initialize(client, **options, &block)
         raise ArgumentError, 'block must be provided' unless block_given?
 

--- a/lib/redd/models/private_message.rb
+++ b/lib/redd/models/private_message.rb
@@ -41,8 +41,8 @@ module Redd
       property :subreddit, with: ->(s) { Subreddit.new(client, display_name: s) if s }
 
       # @!attribute [r] replies
-      #   @return [Listing<PrivateMessage>]
-      property :replies, with: ->(l) { Listing.new(client, l[:data]) if l.is_a?(Hash) }
+      #   @return [ModelListing<PrivateMessage>]
+      property :replies, with: ->(l) { ModelListing.new(client, l[:data]) if l.is_a?(Hash) }
 
       # @!attribute [r] id
       #   @return [String] the message id

--- a/lib/redd/models/searchable.rb
+++ b/lib/redd/models/searchable.rb
@@ -18,7 +18,7 @@ module Redd
       #   search results by
       # @option params [:relevance, :hot, :top, :new, :comments] :sort the sort order of results
       # @option params [String] :restrict_to restrict by subreddit (prefer {Subreddit#search})
-      # @return [Listing<Comment, Submission>] the search results
+      # @return [ModelListing<Comment, Submission>] the search results
       def search(query, **params)
         params[:q] = query
         params[:t] = params.delete(:time) if params.key?(:time)

--- a/lib/redd/models/session.rb
+++ b/lib/redd/models/session.rb
@@ -69,7 +69,7 @@ module Redd
 
       # Get submissions or comments by their fullnames.
       # @param fullnames [String, Array<String>] one or an array of fullnames (e.g. t3_abc1234)
-      # @return [Listing<Submission, Comment>]
+      # @return [ModelListing<Submission, Comment>]
       # @deprecated Try the lazier {#from_fullnames} instead.
       def from_ids(*fullnames)
         client.model(:get, '/api/info', id: fullnames.join(','))
@@ -109,7 +109,7 @@ module Redd
       # @option params [String] :before return results before the given fullname
       # @option params [Integer] :count (0) the number of items already seen in the listing
       # @option params [1..100] :limit (25) the maximum number of things to return
-      # @return [Listing<Comment, PrivateMessage>]
+      # @return [ModelListing<Comment, PrivateMessage>]
       def my_messages(category: 'inbox', mark: false, **params)
         client.model(:get, "/message/#{category}.json", params.merge(mark: mark))
       end
@@ -170,7 +170,7 @@ module Redd
       # @option params [String] :before return results before the given fullname
       # @option params [Integer] :count (0) the number of items already seen in the listing
       # @option params [1..100] :limit (25) the maximum number of things to return
-      # @return [Listing<Subreddit>]
+      # @return [ModelListing<Subreddit>]
       def my_subreddits(type, **params)
         client.model(:get, "/subreddits/mine/#{type}", params)
       end

--- a/lib/redd/models/submission.rb
+++ b/lib/redd/models/submission.rb
@@ -39,7 +39,7 @@ module Redd
       # @option params [String] :before return results before the given fullname
       # @option params [Integer] :count (0) the number of items already seen in the listing
       # @option params [1..100] :limit (25) the maximum number of things to return
-      # @return [Listing<Submission>]
+      # @return [ModelListing<Submission>]
       def duplicates(**params)
         client.unmarshal(client.get("/duplicates/#{read_attribute(:id)}", params).body[1])
       end

--- a/lib/redd/models/subreddit.rb
+++ b/lib/redd/models/subreddit.rb
@@ -33,7 +33,7 @@ module Redd
       #   when sorting
       #
       # @note The option :time only applies to the top and controversial sorts.
-      # @return [Listing<Submission, Comment>]
+      # @return [ModelListing<Submission, Comment>]
       def listing(sort, **options)
         options[:t] = options.delete(:time) if options.key?(:time)
         PaginatedListing.new(client, options) do |**req_options|
@@ -68,7 +68,7 @@ module Redd
       # @option params [1..100] :limit the maximum number of things to return
       # @option params [:links, :comments] :only the type of objects required
       #
-      # @return [Listing<Submission, Comment>]
+      # @return [ModelListing<Submission, Comment>]
       def moderator_listing(type, **params)
         client.model(:get, "/r/#{read_attribute(:display_name)}/about/#{type}", params)
       end
@@ -278,7 +278,7 @@ module Redd
       # @option params [1..100] :limit the maximum number of things to return
       # @option params [String] :type filter events to a specific type
       #
-      # @return [Listing<ModAction>]
+      # @return [ModelListing<ModAction>]
       def mod_log(**params)
         client.model(:get, "/r/#{read_attribute(:display_name)}/about/log", params)
       end

--- a/lib/redd/models/subreddit.rb
+++ b/lib/redd/models/subreddit.rb
@@ -191,8 +191,11 @@ module Redd
       #
       # @return [Listing<Hash<Symbol, String>>]
       def flair_listing(**params)
-        res = client.get("/r/#{read_attribute(:display_name)}/api/flairlist", params).body
-        Listing.new(client, children: res[:users], before: res[:prev], after: res[:next])
+        options[:t] = options.delete(:time) if options.key?(:time)
+        PaginatedListing.new(client, options) do |**req_options|
+          res = client.get("/r/#{read_attribute(:display_name)}/api/flairlist", options.merge(req_options)).body
+          Listing.new(client, children: res[:users], before: res[:prev], after: res[:next])
+        end
       end
 
       # Get the user's flair data.

--- a/lib/redd/models/user.rb
+++ b/lib/redd/models/user.rb
@@ -23,7 +23,7 @@ module Redd
       # @option options [:given] :show whether to show the gildings given
       #
       # @note The option :time only applies to the top and controversial sorts.
-      # @return [Listing<Submission>]
+      # @return [ModelListing<Submission>]
       def listing(type, **options)
         options[:t] = options.delete(:time) if options.key?(:time)
         PaginatedListing.new(client, options) do |**req_opts|

--- a/lib/redd/utilities/unmarshaller.rb
+++ b/lib/redd/utilities/unmarshaller.rb
@@ -7,7 +7,7 @@ module Redd
       # Contains the mapping from 'kind' strings to classes.
       # TODO: UserList type!
       MAPPING = {
-        'Listing'      => Models::Listing,
+        'Listing'      => Models::ModelListing,
         't1'           => Models::Comment,
         't2'           => Models::User,
         't3'           => Models::Submission,
@@ -38,7 +38,7 @@ module Redd
       def js_listing(res)
         # One day I'll get to deprecate Ruby 2.2 and jump into the world of Hash#dig.
         return nil unless res[:json] && res[:json][:data] && res[:json][:data][:things]
-        Models::Listing.new(@client, children: res[:json][:data][:things])
+        Models::ModelListing.new(@client, children: res[:json][:data][:things])
       end
 
       # Unmarshal frontend API-style models.
@@ -53,7 +53,7 @@ module Redd
         return nil unless res[:kind] == 'Listing'
         attributes = res[:data]
         attributes[:children].map! { |child| unmarshal(child) }
-        Models::Listing.new(@client, attributes)
+        Models::ModelListing.new(@client, attributes)
       end
 
       # Unmarshal API-provided model.


### PR DESCRIPTION
This resolves a flawed assumption that all listings returned by the Reddit API output Model objects; many return generic objects, such as the **[/r/*subreddit*]/api/flairlist** endpoint.

Fixes issue #93.