### PR TITLE
Drop support for older rubies

### DIFF
--- a/lib/redd.rb
+++ b/lib/redd.rb
@@ -101,7 +101,7 @@ module Redd
 
     def script(opts = {})
       return unless %i[client_id secret username password].all? { |o| opts.include?(o) }
-      auth = AuthStrategies::Script.new(filter_auth(opts))
+      auth = AuthStrategies::Script.new(filter_auth(**opts))
       api = APIClient.new(auth, **filter_api(opts))
       api.tap(&:authenticate)
     end
@@ -115,7 +115,7 @@ module Redd
 
     def userless(opts = {})
       return unless %i[client_id secret].all? { |o| opts.include?(o) }
-      auth = AuthStrategies::Userless.new(filter_auth(opts))
+      auth = AuthStrategies::Userless.new(**filter_auth(opts))
       api = APIClient.new(auth, **filter_api(opts))
       api.tap(&:authenticate)
     end

--- a/lib/redd/models/front_page.rb
+++ b/lib/redd/models/front_page.rb
@@ -33,7 +33,7 @@ module Redd
       # @return [PaginatedListing<Submission>]
       def listing(sort, **options)
         options[:t] = options.delete(:time) if options.key?(:time)
-        PaginatedListing.new(client, options) do |**req_options|
+        PaginatedListing.new(client, **options) do |**req_options|
           client.model(:get, "/#{sort}", options.merge(req_options))
         end
       end

--- a/lib/redd/models/subreddit.rb
+++ b/lib/redd/models/subreddit.rb
@@ -36,7 +36,7 @@ module Redd
       # @return [Listing<Submission, Comment>]
       def listing(sort, **options)
         options[:t] = options.delete(:time) if options.key?(:time)
-        PaginatedListing.new(client, options) do |**req_options|
+        PaginatedListing.new(client, **options) do |**req_options|
           client.model(
             :get, "/r/#{read_attribute(:display_name)}/#{sort}", options.merge(req_options)
           )

--- a/lib/redd/models/user.rb
+++ b/lib/redd/models/user.rb
@@ -26,7 +26,7 @@ module Redd
       # @return [Listing<Submission>]
       def listing(type, **options)
         options[:t] = options.delete(:time) if options.key?(:time)
-        PaginatedListing.new(client, options) do |**req_opts|
+        PaginatedListing.new(client, **options) do |**req_opts|
           client.model(:get, "/user/#{read_attribute(:name)}/#{type}.json", options.merge(req_opts))
         end
       end

--- a/lib/spinels-redd.rb
+++ b/lib/spinels-redd.rb
@@ -1,0 +1,1 @@
+require 'redd'

--- a/redd.gemspec
+++ b/redd.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
   spec.summary  = 'A batteries-included API wrapper for reddit.'
   spec.homepage = 'https://github.com/avinashbot/redd'
   spec.license  = 'MIT'
-  spec.required_ruby_version = '>= 2.1.0'
+  spec.required_ruby_version = '>= 2.6'
 
   spec.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})

--- a/redd.gemspec
+++ b/redd.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
   spec.add_dependency 'lazy_lazer', '~> 0.8.1'
 
   spec.add_development_dependency 'pry', '~> 0.10'
-  spec.add_development_dependency 'bundler', '~> 1.14'
+  spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'yard', '~> 0.9.9'
   spec.add_development_dependency 'rubocop', '~> 0.50'

--- a/spinels-redd.gemspec
+++ b/spinels-redd.gemspec
@@ -5,12 +5,12 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'redd/version'
 
 Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
-  spec.name     = 'redd'
+  spec.name     = 'spinels-redd'
   spec.version  = Redd::VERSION
   spec.authors  = ['Avinash Dwarapu']
   spec.email    = ['avinash@dwarapu.me']
   spec.summary  = 'A batteries-included API wrapper for reddit.'
-  spec.homepage = 'https://github.com/avinashbot/redd'
+  spec.homepage = 'https://github.com/spinels/redd'
   spec.license  = 'MIT'
   spec.required_ruby_version = '>= 2.6'
 


### PR DESCRIPTION
Dropping the support for older Ruby versions to try and stay up to date. (2.1 almost released 10 years ago 😱 )

Some other things not entirely related to branch:
* Upgrade bundler version
* Publish gem as `spinels-redd`
* Add support for Ruby 3