### PR TITLE
HTTP.timeout now assumes klass based on input

### DIFF
--- a/lib/redd/client.rb
+++ b/lib/redd/client.rb
@@ -85,7 +85,7 @@ module Redd
       # TODO: Make timeouts configurable
       @connection ||= HTTP.persistent(@endpoint)
                           .headers('User-Agent' => @user_agent)
-                          .timeout(:per_operation, write: 5, connect: 5, read: 5)
+                          .timeout(write: 5, connect: 5, read: 5)
     end
   end
 end

--- a/redd.gemspec
+++ b/redd.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'http', '~> 2.2'
+  spec.add_dependency 'http', '>= 4.0', '< 6.0'
   spec.add_dependency 'lazy_lazer', '~> 0.8.1'
 
   spec.add_development_dependency 'pry', '~> 0.10'


### PR DESCRIPTION
As of https://github.com/httprb/http/pull/446

Increasing the http dependancy to `4.0` where this change is released.